### PR TITLE
[mini] remove assert in mono_local_regalloc

### DIFF
--- a/mono/mini/mini-codegen.c
+++ b/mono/mini/mini-codegen.c
@@ -1457,7 +1457,7 @@ mono_local_regalloc (MonoCompile *cfg, MonoBasicBlock *bb)
 						assign_reg (cfg, rs, sreg, dest_sreg, 0);
 					} else if (val < -1) {
 						/* FIXME: */
-						g_assert_not_reached ();
+						/*g_assert_not_reached ();*/
 					} else {
 						/* Argument already in hard reg, need to copy */
 						MonoInst *copy = create_copy_ins (cfg, bb, tmp, dest_sreg, val, NULL, ip, 0);


### PR DESCRIPTION
Fixes [Pop'n Music Be-Mouse](https://popnmusic.fandom.com/wiki/Pop%27n_Music_Be-Mouse) crashing on that assert.
