### PR TITLE
corlib: Add private IsolatedStorageFile field used by an application.

### DIFF
--- a/mcs/class/corlib/System.IO.IsolatedStorage/IsolatedStorageFile.cs
+++ b/mcs/class/corlib/System.IO.IsolatedStorage/IsolatedStorageFile.cs
@@ -379,7 +379,20 @@ namespace System.IO.IsolatedStorage {
 
 		// non-static stuff
 
-		private DirectoryInfo directory;
+		private DirectoryInfo _directory;
+		private string m_RootDir;
+		private DirectoryInfo directory
+		{
+			get
+			{
+				return _directory;
+			}
+			set
+			{
+				_directory = value;
+				m_RootDir = _directory.FullName + Path.DirectorySeparatorChar;
+			}
+		}
 
 		private IsolatedStorageFile (IsolatedStorageScope scope)
 		{

--- a/mcs/class/corlib/Test/System.IO.IsolatedStorage/IsolatedStorageFileTest.cs
+++ b/mcs/class/corlib/Test/System.IO.IsolatedStorage/IsolatedStorageFileTest.cs
@@ -626,6 +626,30 @@ namespace MonoTests.System.IO.IsolatedStorageTest {
 		}
 
 		[Test]
+		public void RootDirField ()
+		{
+			// Used via reflection by Let's Build a Zoo
+			var isf = IsolatedStorageFile.GetUserStoreForDomain ();
+
+			isf.CreateDirectory ("testdir");
+
+			try
+			{
+				var root_field = typeof(IsolatedStorageFile).GetField ("m_RootDir", BindingFlags.NonPublic|BindingFlags.Instance);
+				Assert.IsNotNull (root_field);
+
+				string root_dir = (string)root_field.GetValue (isf);
+				Assert.IsNotNull (root_dir);
+
+				Assert.IsTrue (Directory.Exists (root_dir + "testdir"), root_dir);
+			}
+			finally
+			{
+				isf.DeleteDirectory ("testdir");
+			}
+		}
+
+		[Test]
 		public void UsedSize ()
 		{
 			IsolatedStorageFile isf = IsolatedStorageFile.GetUserStoreForAssembly ();


### PR DESCRIPTION
There's info about this field's usage in referencesource, but
we can't import that implementation because it relies on internal
calls we don't have.

For https://github.com/ValveSoftware/Proton/issues/5288