### PR TITLE
mscorlib: Fix creation of the default encoding on Windows.

### DIFF
--- a/mcs/class/corlib/System.Text/EncodingHelper.cs
+++ b/mcs/class/corlib/System.Text/EncodingHelper.cs
@@ -80,6 +80,14 @@ internal static partial class EncodingHelper
 						int code_page = 1;
 						
 						string code_page_name = InternalCodePage (ref code_page);
+						// Wine Mono hack: InternalCodePage on Windows returns CP<number>
+						// from the ACP, but we can't get most encodings this way, so
+						// pull out the number and use that.
+						if (code_page == -1 && code_page_name.StartsWith ("CP"))
+						{
+							if (!int.TryParse(code_page_name.Substring (2), out code_page))
+								code_page = -1;
+						}
 						try {
 							if (code_page == -1)
 								enc = Encoding.GetEncoding (code_page_name);


### PR DESCRIPTION
This makes it possible for Encoding.Default to be set based on the active code page instead of UTF8.

It's odd because looking at the code, this does seem like a bug, but Mono seems to regard an Encoding.Default of UTF8 on Windows as intended behavior.