### PR TITLE
Set AppDomainSetup.TargetFrameworkName using TargetFrameworkAttribute.FrameworkName

### DIFF
--- a/mcs/class/corlib/System/AppDomainSetup.cs
+++ b/mcs/class/corlib/System/AppDomainSetup.cs
@@ -42,6 +42,8 @@ using System.Runtime.Serialization.Formatters.Binary;
 
 using System.Runtime.Hosting;
 using System.Security.Policy;
+using System.Runtime.Versioning;
+using System.Reflection;
 
 namespace System
 {
@@ -345,7 +347,8 @@ namespace System
 			}
 		}
 
-		public string TargetFrameworkName { get; set; }
+		public string TargetFrameworkName =>
+			Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName;
 
 		public ActivationArguments ActivationArguments {
 			get {


### PR DESCRIPTION
This is used by WPF AppContext switches to tweak various target-specific behaviors. 