### PR TITLE
Add a method for skipping the AppDomain library path search.

### DIFF
--- a/mono/metadata/assembly.h
+++ b/mono/metadata/assembly.h
@@ -105,6 +105,18 @@ void          mono_install_assembly_preload_hook (MonoAssemblyPreLoadFunc func, 
 MONO_API MONO_RT_EXTERNAL_ONLY
 void          mono_install_assembly_refonly_preload_hook (MonoAssemblyPreLoadFunc func, void* user_data);
 
+/* Wine Mono extension: allows for interrupting later preload hooks */
+typedef MonoAssembly * (*WineMonoAssemblyPreLoadFunc) (MonoAssemblyName *aname,
+						   char **assemblies_path,
+						   int *halt_search,
+						   void* user_data);
+
+MONO_API MONO_RT_EXTERNAL_ONLY
+void          wine_mono_install_assembly_preload_hook (WineMonoAssemblyPreLoadFunc func, void* user_data);
+
+MONO_API MONO_RT_EXTERNAL_ONLY
+void          mono_install_assembly_preload_hook (MonoAssemblyPreLoadFunc func, void* user_data);
+
 MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_assembly_invoke_load_hook (MonoAssembly *ass);
 


### PR DESCRIPTION
For https://github.com/ValveSoftware/Proton/issues/5151. The game ships one of the XNA dll's in its own directory, but not all of them. Because of how we override XNA with FNA, this means the dll's are mixed, which doesn't work because XNA was not designed with a clean separation between these dll's. It works fine with either FNA or XNA as long as they're not mixed.

Mono already has a facility (`mono_is_problematic_image`) for refusing to load "broken" dll's shipped with applications, but it doesn't quite make sense here. The XNA dll's are not broken in Wine Mono (at least not anymore), what's broken is mixing them with FNA. Using this for XNA dll's would mean that Mono refuses to load them at all, taking away the option to use native.

We've also had issues in the past with applications shipping .NET Framework dll's which rely on internals and can't work in Mono. In those cases, the dll's should be considered "broken" so they don't load, but a user-configurable option would enable a work-around without modifying code or messing with the application's files.

The plan is to allow overrides like `WINE_MONO_OVERRIDES=Microsoft.Xna.Framework.*,Gac=n,PrivatePath=n` to skip both GAC and the normal search path (usually just the exe directory), and default to this for XNA4 like we do for the GAC setting now.

Another possibility would be to reconsider the default of using FNA, but I still feel that FNA is likely to work better overall, due to its lower system requirements and its ongoing maintenance and use on a wide variety of platforms.