### PR TITLE
Fix Mono not saving configuration values with a default settings file.

### DIFF
--- a/mcs/class/System/System.Configuration/CustomizableFileSettingsProvider.cs
+++ b/mcs/class/System/System.Configuration/CustomizableFileSettingsProvider.cs
@@ -627,6 +627,10 @@ namespace System.Configuration
 				if (value.Property.Attributes.Contains (typeof (ApplicationScopedSettingAttribute)))
 					continue;
 
+				// Don't try to save unchanged values.
+				if (!value.IsDirty)
+					continue;
+
 				hasChanges = true;
 				SettingElement element = userSection.Settings.Get (value.Name);
 				if (element == null) {

--- a/mcs/class/System/System.Configuration/SettingElement.cs
+++ b/mcs/class/System/System.Configuration/SettingElement.cs
@@ -95,11 +95,8 @@ namespace System.Configuration
 
 		public override bool Equals (object settings)
 		{
-			SettingElement e = settings as SettingElement;
-			if (e == null)
-				return false;
-
-			return e.SerializeAs == SerializeAs && e.Value == Value && e.Name == Name;
+			SettingElement u = settings as SettingElement;
+			return (u != null && base.Equals(settings) && Object.Equals(u.Value, Value));
 		}
 
 		public override int GetHashCode ()

--- a/mcs/class/System/System.Configuration/SettingValueElement.cs
+++ b/mcs/class/System/System.Configuration/SettingValueElement.cs
@@ -80,7 +80,8 @@ namespace System.Configuration
 
 		public override bool Equals (object settingValue)
 		{
-			throw new NotImplementedException ();
+			SettingValueElement u = settingValue as SettingValueElement;
+			return (u != null && Object.Equals(u.ValueXml, ValueXml)); 
 		}
 
 		public override int GetHashCode ()

--- a/mcs/class/System/System.Configuration/SettingValueElement.cs
+++ b/mcs/class/System/System.Configuration/SettingValueElement.cs
@@ -39,6 +39,7 @@ namespace System.Configuration
 		: ConfigurationElement
 #endif
 	{
+		private bool isModified = false;
 #if XML_DEP
 		XmlNode node;
 
@@ -64,8 +65,13 @@ namespace System.Configuration
 
 #if (XML_DEP)
 		public XmlNode ValueXml {
-			get { return node; }
-			set { node = value; }
+			get {
+				return node;
+			}
+			set {
+				node = value;
+				isModified = true;
+			}
 		}
 
 #if (CONFIGURATION_DEP)
@@ -92,7 +98,7 @@ namespace System.Configuration
 #if (CONFIGURATION_DEP)
 		protected override bool IsModified ()
 		{
-			return original != node;
+			return isModified;
 		}
 
 		protected override void Reset (ConfigurationElement parentElement)
@@ -102,7 +108,7 @@ namespace System.Configuration
 
 		protected override void ResetModified ()
 		{
-			node = original;
+			isModified = false;
 		}
 #endif
 


### PR DESCRIPTION
Signed-off-by: Bernhard Kölbl <besentv@gmail.com>

Not sure if this approach is correct. Take it with a grain of salt.
