### PR TITLE
Override assembly names loaded through AssemblyResolve handlers when searching currently loaded assemblies.

### DIFF
--- a/mono/metadata/assembly-internals.h
+++ b/mono/metadata/assembly-internals.h
@@ -34,6 +34,9 @@ G_ENUM_FUNCTIONS (MonoAssemblyNameEqFlags)
 void
 mono_assembly_name_free_internal (MonoAssemblyName *aname);
 
+void
+mono_assembly_name_copy (MonoAssemblyName *dest, MonoAssemblyName *src);
+
 gboolean
 mono_assembly_name_culture_is_neutral (const MonoAssemblyName *aname);
 

--- a/mono/metadata/assembly.c
+++ b/mono/metadata/assembly.c
@@ -3284,6 +3284,33 @@ mono_assembly_load_from (MonoImage *image, const char *fname,
 }
 
 /**
+* mono_assembly_name_copy:
+* \param dst destination assembly name
+* \param src source assembly name
+*
+* Copies the src assembly name object to dst, including the name members.
+*/
+void
+mono_assembly_name_copy (MonoAssemblyName *dest, MonoAssemblyName *src)
+{
+	memcpy (dest, src, sizeof(MonoAssemblyName));
+
+	dest->name = g_strdup (dest->name);
+	dest->culture = g_strdup (dest->culture);
+	dest->hash_value = g_strdup (dest->hash_value);
+
+	if (src->public_key) {
+		const gchar *pkey_end;
+		int len = mono_metadata_decode_blob_size ((const gchar*) src->public_key, &pkey_end);
+		pkey_end += len; /* move to end */
+		size_t size = pkey_end - (const gchar*)src->public_key;
+		guchar *tmp = g_new (guchar, size);
+		memcpy (tmp, src->public_key, size);
+		dest->public_key = tmp;
+	}
+}
+
+/**
  * mono_assembly_name_free_internal:
  * \param aname assembly name to free
  * 

--- a/mono/metadata/domain-internals.h
+++ b/mono/metadata/domain-internals.h
@@ -371,6 +371,7 @@ struct _MonoDomain {
 	 * list.
 	 */
 	GSList             *domain_assemblies;
+	GSList             *assembly_aliases;
 	MonoAssembly       *entry_assembly;
 	char               *friendly_name;
 	/* maps remote class key -> MonoRemoteClass */

--- a/mono/metadata/metadata-internals.h
+++ b/mono/metadata/metadata-internals.h
@@ -176,6 +176,13 @@ struct _MonoAssemblyName {
 	MonoBoolean without_public_key_token;
 };
 
+struct _MonoAssemblyAlias {
+	MonoAssemblyName aname;
+	MonoAssembly *assembly;
+};
+
+typedef struct _MonoAssemblyAlias MonoAssemblyAlias;
+
 struct MonoTypeNameParse {
 	char *name_space;
 	char *name;

--- a/mono/tests/Makefile.am
+++ b/mono/tests/Makefile.am
@@ -294,6 +294,7 @@ TESTS_CS_SRC=		\
 	assemblyresolve_event5.cs	\
 	assemblyresolve_event6.cs	\
 	assemblyresolve_event7.cs	\
+	assemblyresolve_event8.cs   \
 	checked.cs		\
 	char-isnumber.cs	\
 	field-layout.cs		\
@@ -2809,6 +2810,12 @@ assemblyresolve_event5.exe: assemblyresolve_event5_helper.dll
 
 assemblyresolve_event6.exe$(PLATFORM_AOT_SUFFIX): assemblyresolve_asm.dll$(PLATFORM_AOT_SUFFIX) assemblyresolve_deps/Test.dll$(PLATFORM_AOT_SUFFIX) assemblyresolve_deps/TestBase.dll$(PLATFORM_AOT_SUFFIX)
 assemblyresolve_event6.exe: assemblyresolve_asm.dll assemblyresolve_deps/Test.dll assemblyresolve_deps/TestBase.dll
+
+assemblyresolve_event8_helper.dll: $(srcdir)/assemblyresolve_event8_helper.cs
+	$(MCS) -target:library -out:assemblyresolve_deps/assemblyresolve_event8_helper.dll $(srcdir)/assemblyresolve_event8_helper.cs
+	$(MCS) -target:library -out:assemblyresolve_deps/assemblyresolve_event8_helper2.dll $(srcdir)/assemblyresolve_event8_helper.cs
+
+assemblyresolve_event8.exe: assemblyresolve_event8_helper.dll
 
 # We use 'test-support-files' to handle an ordering issue between the 'mono/' and 'runtime/' directories
 bug-80307.exe: $(srcdir)/bug-80307.cs

--- a/mono/tests/assemblyresolve_event8.cs
+++ b/mono/tests/assemblyresolve_event8.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Reflection;
+using System.IO;
+
+namespace Test
+{
+    internal class Program
+    {
+        static int Main()
+        {
+            AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
+            var asm = Assembly.Load("assemblyresolve_event8_helper, Version=0.0.0.0, Culture=neutral");
+            var asm2 = Assembly.Load("assemblyresolve_event8_helper, Version=0.0.0.0, Culture=neutral");
+
+            var instance = asm.CreateInstance("NullLibrary.Class1", true);
+
+            var method = asm.GetType("NullLibrary.Class1").GetMethod("DoThing");
+            method.Invoke(instance, null);
+
+            return asm == asm2 ? 0 : 1;
+        }
+
+        private static Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            var name = new AssemblyName(args.Name);
+            if (name.Name == "assemblyresolve_event8_helper")
+            {
+                var bytes = File.ReadAllBytes("assemblyresolve_deps/assemblyresolve_event8_helper2.dll");
+                var asm = Assembly.Load(bytes);
+                Console.WriteLine("requested " + name);
+                Console.WriteLine("loaded GetName " + asm.GetName());
+                Console.WriteLine("loaded ToString " + asm);
+                return asm;
+            }
+
+            return null;
+        }
+    }
+}

--- a/mono/tests/assemblyresolve_event8_helper.cs
+++ b/mono/tests/assemblyresolve_event8_helper.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace NullLibrary
+{
+    public class Class1
+    {
+        public void DoThing()
+        {
+            Console.WriteLine("thing!");
+        }
+    }
+}


### PR DESCRIPTION
The program that led me down this rabbit hole is STORY OF SEASONS: A Wonderful Life's launcher. (steam appid 2111170).

It uses an AssemblyResolve handler to load assemblies from its own resources, but it ships a version of System.Threading.Tasks.Extensions that doesn't match the version requested by its assemblies.

Framework handles this by assuming whatever's returned from AssemblyResolve handlers is the requested assembly and caching that for future loads.

Mono doesn't do this and double loads this assembly (due to two of the launcher's dependencies triggering a load), which leads to a failure to setup a vtable due to mismatching types (they're the same type, but loaded from two different instances of the same assembly).

I have a more realistic repro of the issue [here](https://github.com/vitorhnn/SOSRepro). It _should_ build fine by just using `msbuild`

Not entirely happy with this solution, but the bits of the assembly loader that insert the assembly into `MonoDomain::domain_assemblies` do not receive the name it was requested under, and passing that in would entail changing parts of Mono's assembly load hooks, which I wasn't comfortable with. Let me know if that would be preferrable and I can try to go for it.