### PR TITLE
Support logging of GC invocations and methods enter / leave to ftrace.

### DIFF
--- a/mono/mini/trace.c
+++ b/mono/mini/trace.c
@@ -26,6 +26,7 @@
 #include <mono/utils/mono-memory-model.h>
 #include "trace.h"
 #include <mono/metadata/callspec.h>
+#include <mono/utils/ftrace.h>
 
 #if _MSC_VER
 #pragma warning(disable:4312) // FIXME pointer cast to different size
@@ -167,6 +168,7 @@ mono_trace_enter_method (MonoMethod *method, MonoJitInfo *ji, MonoProfilerCallCo
 	if (!ji)
 		ji = mini_jit_info_table_find (mono_domain_get (), (char *)MONO_RETURN_ADDRESS (), NULL);
 
+	FTRACE("ENTER:%c %s", frame_kind (ji), fname);
 	printf ("ENTER:%c %s(", frame_kind (ji), fname);
 	g_free (fname);
 
@@ -354,6 +356,7 @@ mono_trace_leave_method (MonoMethod *method, MonoJitInfo *ji, MonoProfilerCallCo
 	if (!ji)
 		ji = mini_jit_info_table_find (mono_domain_get (), (char *)MONO_RETURN_ADDRESS (), NULL);
 
+	FTRACE("LEAVE:%c %s", frame_kind (ji), fname);
 	printf ("LEAVE:%c %s(", frame_kind (ji), fname);
 	g_free (fname);
 

--- a/mono/sgen/sgen-gc.c
+++ b/mono/sgen/sgen-gc.c
@@ -197,6 +197,8 @@
 #include <mono/utils/mono-mmap-internals.h>
 #include <mono/utils/unlocked.h>
 
+#include <mono/utils/ftrace.h>
+
 #undef pthread_create
 #undef pthread_join
 #undef pthread_detach
@@ -2616,7 +2618,10 @@ sgen_ensure_free_space (size_t size, int generation)
 
 	if (generation_to_collect == -1)
 		return;
+
+	FTRACE_BLOCK_START("GC %s", reason)
 	sgen_perform_collection (size, generation_to_collect, reason, forced, TRUE);
+	FTRACE_BLOCK_END()
 }
 
 /*

--- a/mono/utils/Makefile.am
+++ b/mono/utils/Makefile.am
@@ -238,7 +238,9 @@ monoutils_sources = \
 	options.h \
 	options-def.h \
 	options.c \
-	ftnptr.h
+	ftnptr.h \
+	ftrace.c \
+	ftrace.h
 
 arch_sources = 
 

--- a/mono/utils/ftrace.c
+++ b/mono/utils/ftrace.c
@@ -1,0 +1,62 @@
+#include <stdlib.h>
+#include <fcntl.h>
+#include <stdio.h>
+
+#include <mono/utils/atomic.h>
+
+#include "ftrace.h"
+
+int ftrace_fd = -1;
+
+int __wine_dbg_ftrace_init(void)
+{
+    if (ftrace_fd == -1)
+    {
+        const char *fn;
+        int fd;
+
+        if (!(fn = getenv( "WINE_FTRACE_FILE" )))
+        {
+            ftrace_fd = -2;
+            return 0;
+        }
+        if ((fd = open( fn, O_WRONLY )) == -1)
+        {
+            ftrace_fd = -2;
+            return 0;
+        }
+        if (mono_atomic_cas_i32(&ftrace_fd, fd, -1) != -1)
+            close( fd );
+    }
+
+    return ftrace_fd >= 0;
+}
+
+unsigned int __wine_dbg_ftrace( char *str, unsigned int str_size, unsigned int ctx )
+{
+    static volatile gint32 curr_ctx;
+    unsigned int str_len;
+    char ctx_str[64];
+    int ctx_len;
+
+    if (ftrace_fd < 0) return ~0u;
+
+    if (ctx == ~0u) ctx_len = 0;
+    else if (ctx) ctx_len = sprintf( ctx_str, " (end_ctx=%u)", ctx );
+    else
+    {
+        ctx = mono_atomic_inc_i32(&curr_ctx);
+        ctx_len = sprintf( ctx_str, " (begin_ctx=%u)", ctx );
+    }
+
+    str_len = strlen(str);
+    if (ctx_len > 0)
+    {
+        if (str_size < ctx_len) return ~0u;
+        if (str_len + ctx_len > str_size) str_len = str_size - ctx_len;
+        memcpy( &str[str_len], ctx_str, ctx_len );
+        str_len += ctx_len;
+    }
+    write( ftrace_fd, str, str_len );
+    return ctx;
+}

--- a/mono/utils/ftrace.h
+++ b/mono/utils/ftrace.h
@@ -1,0 +1,34 @@
+#ifndef __WINE_FTRACE__
+#define __WINE_FTRACE__
+
+#include <stdarg.h>
+
+unsigned int __wine_dbg_ftrace( char *str, unsigned int str_size, unsigned int ctx );
+int __wine_dbg_ftrace_init(void);
+extern int ftrace_fd;
+
+static inline unsigned int __wine_dbg_ftrace_printf( unsigned int ctx, const char *format, ...)
+{
+    char buffer[256];
+
+    va_list args;
+
+    va_start( args, format );
+    vsnprintf( buffer, sizeof(buffer), format, args );
+    va_end( args );
+    return __wine_dbg_ftrace(buffer, sizeof(buffer), ctx);
+}
+
+#define FTRACE_ON (ftrace_fd == -1 ? __wine_dbg_ftrace_init() : ftrace_fd >= 0)
+
+#define FTRACE(...)                do { if (FTRACE_ON) __wine_dbg_ftrace_printf( -1, __VA_ARGS__ ); } while (0)
+
+#define FTRACE_BLOCK_START(...) do { \
+                                    unsigned int ctx = FTRACE_ON ? __wine_dbg_ftrace_printf( 0, __VA_ARGS__ ) : 0; \
+                                    do {
+
+#define FTRACE_BLOCK_END()          } while (0); \
+                                    if (FTRACE_ON) __wine_dbg_ftrace_printf( ctx, "" ); \
+                                } while (0);
+
+#endif


### PR DESCRIPTION
This is an example of how it may look like in gpuvis: 
![1](https://github.com/madewokherd/mono/assets/3761645/f2c116ce-130f-402d-b7c3-ea6f0053a268)

This requires some manual setup of ftrace filesystem so trace_marker file is available to the process (which file is specified with WINE_FTRACE_FILE which, if successfully open, triggers recording of markers). E. g., like this:
```
sudo mkdir ~/tracing
sudo mount -t tracefs nodev ~/tracing
sudo chmod a+rx ~/tracing
sudo chmod a+rw ~/tracing/trace_marker
```
and then running with WINE_FTRACE_FILE=~/tracing/trace_marker

The part related to method leave / enter is a bit challenging to use OOTB as by default there are way too many events and that is not feasible to handle in gpuvis currently. Also reporting that as interval is complicated (needs tracking the context and unwinds). Yet if it is possible to reasonably limit the amount of logged methods that might work too.