### PR TITLE
System.Configuration: User configuration path bugfixes and code cleanup.

### DIFF
--- a/mcs/class/System/net_4_x_System.dll.sources
+++ b/mcs/class/System/net_4_x_System.dll.sources
@@ -28,6 +28,7 @@ Microsoft.Win32/UserPreferenceChangingEventHandler.cs
 
 System/MonoToolsLocator.cs
 
+../referencesource/System.Configuration/System/Configuration/ClientConfigPaths.cs
 System.CodeDom.Compiler/*.cs
 System.Configuration/ApplicationScopedSettingAttribute.cs
 System.Configuration/ApplicationSettingsBase.cs

--- a/mcs/class/referencesource/System.Configuration/System/Configuration/ClientConfigPaths.cs
+++ b/mcs/class/referencesource/System.Configuration/System/Configuration/ClientConfigPaths.cs
@@ -650,6 +650,16 @@ namespace System.Configuration {
                 if (limitSize) {
                     validated = (validated.Length > MAX_LENGTH_TO_USE) ? validated.Substring(0, MAX_LENGTH_TO_USE) : validated;
                 }
+
+		/*
+		 * For Mono compatibility:
+		 * Mono creates/accesses the generated user configuration file paths
+		 * through a different set of API calls than referencesource does.
+		 * As a result of this, the trailing period in directory names is
+		 * not truncated, which results in an inability to access the user
+		 * configuration file. We'll add a workaround for this here.
+		 */
+		validated = validated.TrimEnd('.');
             }
 
             return validated;


### PR DESCRIPTION
With these patches, the newly added tests t49 and t50 pass. These bring us closer to native behavior WRT user configuration path names, and also fix a bug that occurs when there's a trailing `.` in user configuration path directory names.