### PR TITLE
System.Drawing.Icon: Allow constructing from cursor handle.

### DIFF
--- a/mcs/class/System.Drawing/System.Drawing/Icon.cs
+++ b/mcs/class/System.Drawing/System.Drawing/Icon.cs
@@ -126,8 +126,6 @@ namespace System.Drawing
 		private Icon (IntPtr handle)
 		{
 			this.handle = handle;
-			bitmap = Bitmap.FromHicon (handle);
-			iconSize = new Size (bitmap.Width, bitmap.Height);
 			if (GDIPlus.RunningOnUnix ()) {
 				bitmap = Bitmap.FromHicon (handle);
 				iconSize = new Size (bitmap.Width, bitmap.Height);
@@ -136,9 +134,8 @@ namespace System.Drawing
 				IconInfo ii;
 				GDIPlus.GetIconInfo (handle, out ii);
 
-				// If this structure defines an icon, the hot spot is always in the center of the icon
-				iconSize = new Size (ii.xHotspot * 2, ii.yHotspot * 2);
 				bitmap = (Bitmap) Image.FromHbitmap (ii.hbmColor);
+				iconSize = new Size (bitmap.Width, bitmap.Height);
 			}
 			undisposable = true;
 		}

--- a/mcs/class/System.Drawing/Test/System.Drawing/TestIcon.cs
+++ b/mcs/class/System.Drawing/Test/System.Drawing/TestIcon.cs
@@ -524,6 +524,31 @@ namespace MonoTests.System.Drawing {
 			Assert.Throws<FileNotFoundException> (() => Icon.ExtractAssociatedIcon ("does-not-exists.png"));
 		}
 
+
+		[Test]
+		public void CreateFromCursor ()
+		{
+			IntPtr handle = icon64.Handle;
+			IconInfo ii;
+
+			GDIPlus.GetIconInfo (handle, out ii);
+			ii.IsIcon = false;
+			handle = GDIPlus.CreateIconIndirect (ref ii);
+			Assert.IsNotNull(handle);
+
+			try
+			{
+				Bitmap bitmap = Bitmap.FromHicon(handle);
+				Assert.Fail ("must throw ArgumentException");
+			}
+			catch (ArgumentException)
+			{
+			}
+
+			Icon icon = Icon.FromHandle(handle);
+			Assert.IsNotNull(icon);
+		}
+
 		private static bool RunningOnUnix {
 			get {
 				int p = (int) Environment.OSVersion.Platform;


### PR DESCRIPTION
Fixes Dungeons popping up exception dialog on every mouse move.

The game calls System.Windows.Forms.Cursor.HotSpot. For some reason which is not apparent to me it doesn't use GetIconInfo directly on the cursor handle which I guess would just work. Instead it first does 'currentIcon = Icon.FromHandle(this.Handle);' to create an icon from cursor handle and then does GetIconInfo on this icon handle. That is a lot of extra work involving bitmap creation / copying (which can maybe go?; in this game it is used on each mouse move), but the core problem is not there.

System.Drawing.Icon.FromHandle() should actually succeed with cursor handle (unlike Bitmap.FromHicon which currently correctly fails, as well as underlying GdipCreateBitmapFromHICON(), but is incorrectly used in System.Drawing.Icon.FromHandle).
